### PR TITLE
[WIP] Specify names of processes to monitor by regex pattern

### DIFF
--- a/supervisord.yaml
+++ b/supervisord.yaml
@@ -6,6 +6,8 @@ instances:
       port: 9001
       user: user # optional
       pass: pass # optional
+      proc_regex: # optional. Will monitor all processes that match regular expression
+        - "mygroup:myprocess-??$"
       proc_names: # optional. will monitor all processes if not specified
        - apache2
        - custom_app


### PR DESCRIPTION

This PR adds the ability to specify which processes should be monitored by matching the process names against regex patterns.


- Add proc_regex configuration key. If key is present and not empty, process names must match at least one of the patterns in the list to be monitored
- Update proc_names logic to merge explicit proc_names with proc_regex filter results
 - Add proc_regex section to example configuration
