### PR TITLE
Specify names of processes to monitor by regex pattern

### DIFF
--- a/supervisord.py
+++ b/supervisord.py
@@ -60,7 +60,6 @@ class SupervisordCheck(AgentCheck):
         # Add regex matches to process list
         if proc_regex and len(proc_regex):
             patterns = '(?:%s)' % '|'.join(proc_regex)
-            print patterns
             for process in processes:
                 if re.match(patterns, process['name']) and process not in monitored_processes:
                     monitored_processes.append(process)

--- a/supervisord.py
+++ b/supervisord.py
@@ -60,9 +60,10 @@ class SupervisordCheck(AgentCheck):
         # Add regex matches to process list
         if proc_regex and len(proc_regex):
             patterns = '(?:%s)' % '|'.join(proc_regex)
+            print patterns
             for process in processes:
-                if re.match(patterns, process) and process not in monitored_processes:
-                    monitored_processes.append(server.supervisor.getProcessInfo(process))
+                if re.match(patterns, process['name']) and process not in monitored_processes:
+                    monitored_processes.append(process)
 
         # Add explicit matches to process list
         if proc_names and len(proc_names):

--- a/supervisord.py
+++ b/supervisord.py
@@ -54,20 +54,16 @@ class SupervisordCheck(AgentCheck):
         proc_names = instance.get('proc_names', [])
         monitored_processes = []
 
-        if not len(proc_regex) and not len(proc_names):
+        if len(proc_regex) == 0 and len(proc_names) == 0:
             monitored_processes = processes
 
-        if len(proc_regex):
-            for pattern, process in itertools.product(proc_regex, processes):
-                if re.match(pattern, process['name']):
-                    if process not in monitored_processes:
-                        monitored_processes.append(process)
+        for pattern, process in itertools.product(proc_regex, processes):
+            if re.match(pattern, process['name']) and process not in monitored_processes:
+                monitored_processes.append(process)
 
-        if len(proc_names):
-            for process in processes:
-                if process['name'] in proc_names:
-                    if process not in monitored_processes:
-                        monitored_processes.append(process)
+        for process in processes:
+            if process['name'] in proc_names and process not in monitored_processes:
+                monitored_processes.append(process)
 
         for proc in monitored_processes:
             proc_name = proc['name']

--- a/supervisord.py
+++ b/supervisord.py
@@ -67,9 +67,9 @@ class SupervisordCheck(AgentCheck):
 
         # Add explicit matches to process list
         if proc_names and len(proc_names):
-            for process in proc_names:
-                if process not in monitored_processes:
-                    monitored_processes.append(server.supervisor.getProcessInfo(process))
+            for proc_name in proc_names:
+                if proc_name not in monitored_processes:
+                    monitored_processes.append(server.supervisor.getProcessInfo(proc_name))
 
         for proc in monitored_processes:
             proc_name = proc['name']

--- a/supervisord.yaml
+++ b/supervisord.yaml
@@ -9,8 +9,8 @@ instances:
       proc_regex: # optional. Will monitor all processes that match regular expression
         - 'mygroup:myprocess-\d\d$'
       proc_names: # optional. Will monitor matching process. Combines with proc_regex matches.
-       - apache2
-       - custom_app
-       - etc
+        - apache2
+        - custom_app
+        - etc
     - name: server1
-      etc
+      ...etc...

--- a/supervisord.yaml
+++ b/supervisord.yaml
@@ -7,7 +7,7 @@ instances:
       user: user # optional
       pass: pass # optional
       proc_regex: # optional. Will monitor all processes that match regular expression
-        - 'mygroup:myprocess-\d\d$'
+        - 'myprocess-\d\d$'
       proc_names: # optional. Will monitor matching process. Combines with proc_regex matches.
         - apache2
         - custom_app

--- a/supervisord.yaml
+++ b/supervisord.yaml
@@ -7,8 +7,8 @@ instances:
       user: user # optional
       pass: pass # optional
       proc_regex: # optional. Will monitor all processes that match regular expression
-        - "mygroup:myprocess-??$"
-      proc_names: # optional. will monitor all processes if not specified
+        - 'mygroup:myprocess-\d\d$'
+      proc_names: # optional. Will monitor matching process. Combines with proc_regex matches.
        - apache2
        - custom_app
        - etc

--- a/supervisord.yaml
+++ b/supervisord.yaml
@@ -6,6 +6,8 @@ instances:
       port: 9001
       user: user # optional
       pass: pass # optional
+      proc_regex: # optional. Will monitor all processes that match regular expression
+        - "mygroup:myprocess-??$"
       proc_names: # optional. will monitor all processes if not specified
        - apache2
        - custom_app


### PR DESCRIPTION
This change set adds the ability to specify the processes to be monitored by matching the process names against regex patterns.
1. Adds "proc_regex" configuration key. If proc_regex key is present and not empty, process names must match at least one of the patterns in the list to be monitored
2. Updates "proc_names" logic to merge explicit proc_names with proc_regex filter results
3. Adds proc_regex section to example configuration
